### PR TITLE
Display "#searchbox" with plain javascript instead of jQuery

### DIFF
--- a/ehsphinx/searchbox.html
+++ b/ehsphinx/searchbox.html
@@ -7,5 +7,7 @@
     <input type="hidden" name="area" value="default" />
   </form>
 </div>
-<script type="text/javascript">$('#searchbox').show(0);</script>
+<script type="text/javascript">
+    document.querySelector("#searchbox").style.display="block";
+</script>
 {%- endif %}


### PR DESCRIPTION
Since Sphinx removed jQuery in v6.0.0